### PR TITLE
simply use output as is

### DIFF
--- a/lib/Nagios/Passive/Gearman.pm
+++ b/lib/Nagios/Passive/Gearman.pm
@@ -37,7 +37,7 @@ start_time=%i.%i
 finish_time=%i.%i
 latency=%i.%i
 return_code=%i
-output=%s %s - %s
+output=%s
 EOT
     my $result = sprintf $template,
         'passive',


### PR DESCRIPTION
otherwise it is not possible to set exact unaltered output